### PR TITLE
Skra'gath damage school & Felguard faction

### DIFF
--- a/Updates/0897_Skra'gath_FelguardAnnihilator.sql
+++ b/Updates/0897_Skra'gath_FelguardAnnihilator.sql
@@ -1,0 +1,2 @@
+UPDATE creature_template SET Faction = 90 WHERE entry = 18604;
+UPDATE creature_template SET DamageSchool = 0 WHERE Entry = 18401;


### PR DESCRIPTION
--Skra'gath is currently set to do shadow damage on hit, this should be melee http://db.excalibur.ws/?npc=18401 as source. Plus a level 68 player couldn't possibly be expected to deal with 2-3k shadow damage hits.
--The heroic version of Felguard Annihilator is currently to a friendly faction. The change sets it to the same enemy faction the normal mode version is set to.